### PR TITLE
CSP policy: add default src none to headers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const FONT_SIZE = SIZE * 0.5;
 const BASELINE_OFFSET_MULTIPLIER = 0.035;
 const HEADERS = {
     'Cache-Control': 'public, max-age=31536000',
+    'Content-Security-Policy': "default-src 'none'"
 };
 
 const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args), ...args));


### PR DESCRIPTION
- Add CSP Policy restrictions in order to avoid XSS via stored custom Avatar Image Upload